### PR TITLE
fix: payment_bulk_detail の access_id がnilを許容するように

### DIFF
--- a/fincode_api_client/lib/fincode_api_client/models/payment_bulk_detail.rb
+++ b/fincode_api_client/lib/fincode_api_client/models/payment_bulk_detail.rb
@@ -502,9 +502,10 @@ module FincodeApiClient
     # Custom attribute writer method with validation
     # @param [Object] access_id Value to be assigned
     def access_id=(access_id)
-      if access_id.nil?
-        fail ArgumentError, 'access_id cannot be nil'
-      end
+      # NOTE: retrieve_payment_bulk_detail_list で FAILED の場合に access_id が nil になることがある
+      # if access_id.nil?
+      #   fail ArgumentError, 'access_id cannot be nil'
+      # end
 
       if access_id.to_s.length > 24
         fail ArgumentError, 'invalid value for "access_id", the character length must be smaller than or equal to 24.'


### PR DESCRIPTION
ymlの定義を直すべきところだが、一旦こちらで暫定対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced payment detail retrieval by allowing scenarios where the payment identifier may be omitted. Provided identifiers still need to meet defined length requirements, ensuring smoother and more flexible processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->